### PR TITLE
Check roughing pump status for interlock

### DIFF
--- a/L2SIVacuum/POUs/Functions/Valves/functions/F_TurboGateValve_Protection_ILK.TcPOU
+++ b/L2SIVacuum/POUs/Functions/Valves/functions/F_TurboGateValve_Protection_ILK.TcPOU
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<TcPlcObject Version="1.1.0.1" ProductVersion="3.1.4022.16">
+<TcPlcObject Version="1.1.0.1" ProductVersion="3.1.4024.0">
   <POU Name="F_TurboGateValve_Protection_ILK" Id="{97c83354-3c90-4840-9b47-f9363c0b62c0}" SpecialFunc="None">
     <Declaration><![CDATA[(* This Function Block evaluates the ILK condition of the Turbo Gate valve *)
 (* The logic Protects the Turbo pump from inlet pressure above the SP*)
@@ -22,7 +22,7 @@ END_VAR
 F_TurboGateValve_ILK := (NOT (i_Turbo.eState = pumpSTOPPED) AND NOT (i_Turbo.eState = pumpFAULT))
 						AND (i_stISG.xPRESS_OK AND i_stISG.rPRESS < i_Turbo.rInletPressureSP)
 						AND (i_stBSG.xPRESS_OK AND i_stBSG.rPRESS < i_Turbo.rBackingPressureSP)
-						AND (ScrollPump.q_xRunDo);
+						AND (ScrollPump.eState = pumpRUNNING);
 ]]></ST>
     </Implementation>
     <LineIds Name="F_TurboGateValve_Protection_ILK">

--- a/L2SIVacuum/POUs/Functions/Valves/functions/F_TurboGateValve_Protection_ILK.TcPOU
+++ b/L2SIVacuum/POUs/Functions/Valves/functions/F_TurboGateValve_Protection_ILK.TcPOU
@@ -19,7 +19,7 @@ END_VAR
     <Implementation>
       <ST><![CDATA[(* This Function Block evaluates the ILK condition of the Turbo Gate valve *)
 (* The logic Protects the Turbo pump from inlet pressure above the SP*)
-F_TurboGateValve_ILK := (NOT (i_Turbo.eState = pumpSTOPPED) AND NOT (i_Turbo.eState = pumpFAULT))
+F_TurboGateValve_Protection_ILK := (NOT (i_Turbo.eState = pumpSTOPPED) AND NOT (i_Turbo.eState = pumpFAULT))
 						AND (i_stISG.xPRESS_OK AND i_stISG.rPRESS < i_Turbo.rInletPressureSP)
 						AND (i_stBSG.xPRESS_OK AND i_stBSG.rPRESS < i_Turbo.rBackingPressureSP)
 						AND (ScrollPump.eState = pumpRUNNING);


### PR DESCRIPTION
DEV: interlock should check for confirmation that the roughing pump is at speed for pumps that support that readout.

It looks like you're setting the scroll pump's `eState` enum quite diligently such that roughing pumps with status indicators check the pump status before moving to the `pumpRUNNING` state. Pumps without the status indicator (e.g. `FB_ScrollPump`) set `eState` using the `q_xRunDo` so their functionality should be untouched. 