### PR TITLE
BUG: Adjust MKS317's limits for the ValidLo state 

### DIFF
--- a/L2SIVacuum/POUs/Functions/Gauges/FB_MKS317.TcPOU
+++ b/L2SIVacuum/POUs/Functions/Gauges/FB_MKS317.TcPOU
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<TcPlcObject Version="1.1.0.1" ProductVersion="3.1.4022.18">
+<TcPlcObject Version="1.1.0.1" ProductVersion="3.1.4024.2">
   <POU Name="FB_MKS317" Id="{8a56f7a2-f285-4648-be2d-40acd79b269f}" SpecialFunc="None">
     <Declaration><![CDATA[(* This function is for the Pirani MKS 317 connected to a 937A/B *)
 (* This function block is used to provide protection and automatic turn on of ion gauges,
@@ -27,8 +27,10 @@ END_VAR
 VAR CONSTANT
 	rMinPressure: REAL := 1E-4;
 	rDefaultVAC_SP: REAL :=5E-2; // Default 50 mT
-	rValidLoBoundary	:	REAL := 0.2;
-	rValidHiBoundary	:	REAL := 9.7; 
+	rValidLoBoundary	:	REAL := 0.22;
+	rValidBoundaryMin	:	REAL := 0.6;
+	rValidHiBoundary	:	REAL := 9.7;
+	rValidHiBoundaryMax	:	REAL := 9.9; 
 	rDisconnectedBoundary	:	REAL := 0.17;
 	rNoSensorBoundary	:	REAL := 10;
 END_VAR
@@ -52,14 +54,14 @@ IF PG.rVAC_SP = 0 THEN
 	PG.rVAC_SP := rDefaultVAC_SP;
 END_IF
 
-IF (rV <=9.7 ) AND (rV>=0.6) THEN
+IF (rV <=rValidHiBoundary ) AND (rV>=rValidBoundaryMin) THEN
 	PG.eState := Valid; // normal
-ELSIF rV >= 0.18 AND rV <= 0.22 THEN
+ELSIF rV >= rDisconnectedBoundary AND rV <= rValidLoBoundary THEN
 	PG.eState := ValidLo; //LO
 	PG.rPRESS := rMinPressure;
-ELSIF rV > 9.7 AND rV<= 9.9 THEN
+ELSIF rV > rValidHiBoundary AND rV<= rValidHiBoundaryMax THEN
 	PG.eState := ValidHi; //HIGH
-ELSIF rV < 0.18 THEN
+ELSIF rV < rDisconnectedBoundary THEN
 	PG.eState := GaugeDisconnected; //not on
 	PG.rPRESS := -1;
 ELSE

--- a/L2SIVacuum/POUs/Functions/Gauges/FB_MKS317.TcPOU
+++ b/L2SIVacuum/POUs/Functions/Gauges/FB_MKS317.TcPOU
@@ -31,7 +31,7 @@ VAR CONSTANT
 	rValidBoundaryMin	:	REAL := 0.6;
 	rValidHiBoundary	:	REAL := 9.7;
 	rValidHiBoundaryMax	:	REAL := 9.9; 
-	rDisconnectedBoundary	:	REAL := 0.17;
+	rDisconnectedBoundary	:	REAL := 0.15;
 	rNoSensorBoundary	:	REAL := 10;
 END_VAR
 ]]></Declaration>

--- a/L2SIVacuum/POUs/Functions/Gauges/FB_MKS317.TcPOU
+++ b/L2SIVacuum/POUs/Functions/Gauges/FB_MKS317.TcPOU
@@ -27,11 +27,11 @@ END_VAR
 VAR CONSTANT
 	rMinPressure: REAL := 1E-4;
 	rDefaultVAC_SP: REAL :=5E-2; // Default 50 mT
+	rDisconnectedBoundary	:	REAL := 0.15;
 	rValidLoBoundary	:	REAL := 0.22;
 	rValidBoundaryMin	:	REAL := 0.6;
 	rValidHiBoundary	:	REAL := 9.7;
 	rValidHiBoundaryMax	:	REAL := 9.9; 
-	rDisconnectedBoundary	:	REAL := 0.15;
 	rNoSensorBoundary	:	REAL := 10;
 END_VAR
 ]]></Declaration>


### PR DESCRIPTION
Hello @ghalym,

This should address the issues described in https://github.com/pcdshub/lcls-twincat-vacuum/issues/36. 

Additionally the FB used an odd mix of constants which were then skipped in favor of hard-coded constants. 

I've set the limit to .15 volts which is probably lower than necessary but I think it should be alright as that voltage range shouldn't have any other meanings.

I also noticed that there used to be a strange deadzone between .6V and .22V. I've left it in but I'm not entirely sure if that's the right decision. 

@slacAWallace